### PR TITLE
Port generic etg to x86 64

### DIFF
--- a/src/Game/ETG.c
+++ b/src/Game/ETG.c
@@ -5808,18 +5808,17 @@ sdword etgVarAssign(Effect *effect, struct etgeffectstatic *stat, ubyte *opcode)
 
 sdword etgFunctionCall(Effect *effect, struct etgeffectstatic *stat, ubyte *opcode)
 {
-    udword param, nParams, returnType;
+    memsize param = 0;
     etgfunctioncall *opptr = (etgfunctioncall *)opcode;
 
-    nParams = opptr->nParameters;
-    returnType = opptr->returnValue;
+    udword nParams = opptr->nParameters;
+    memsize returnValue = opptr->returnValue;
 
     opfunctionentry *entry = NULL;
-    udword currEntry=0;
-        
+    udword currEntry = 0;
     while ((entry = &etgFunctionTable[currEntry++])->name != NULL)
     {
-        if (entry->function == ((etgfunctioncall *)opcode)->function)
+        if (entry->function == opptr->function)
         {
             break;
         }
@@ -5835,9 +5834,9 @@ sdword etgFunctionCall(Effect *effect, struct etgeffectstatic *stat, ubyte *opco
     else
         param = opptr->wrap_function(effect, stat, opptr);
 
-    if (returnType != 0xffffffff)                           //if a return value is desired
+    if (returnValue != MINUS1)                           //if a return value is desired
     {
-        *((udword *)(effect->variable + returnType)) = param;//set the return parameter
+        *((memsize *)(effect->variable + returnValue)) = param;//set the return parameter
     }
 
     return(etgFunctionSize(nParams));

--- a/src/Game/ETG.c
+++ b/src/Game/ETG.c
@@ -6010,63 +6010,6 @@ sdword etgFunctionCall(Effect *effect, struct etgeffectstatic *stat, ubyte *opco
            
 	opfunctionentry *entry;
 
-/*
-    if (((etgfunctioncall *)opcode)->function == etgSpawnNewEffect){
-
-//        dbgMessagef("Function: %lx:%d   -> %s",((etgfunctioncall *)opcode)->function, nParams+((etgfunctioncall *)opcode)->passThis ,  stat->name);
-
-        switch  (nParams+((etgfunctioncall *)opcode)->passThis){
-            case 4: 
-                etgSpawnNewEffect(effect, ((etgfunctioncall *)opcode)->parameter[0].param,1,((etgfunctioncall *)opcode)->parameter[2].param);
-                return (etgFunctionSize(nParams));
-                break;
-            case 5: 
-                etgSpawnNewEffect(effect, ((etgfunctioncall *)opcode)->parameter[0].param,2,((etgfunctioncall *)opcode)->parameter[2].param,((etgfunctioncall *)opcode)->parameter[3].param);
-                return (etgFunctionSize(nParams));
-                break;
-            case 6: 
-                etgSpawnNewEffect(effect, ((etgfunctioncall *)opcode)->parameter[0].param,3,((etgfunctioncall *)opcode)->parameter[2].param,((etgfunctioncall *)opcode)->parameter[3].param,((etgfunctioncall *)opcode)->parameter[4].param);
-                return (etgFunctionSize(nParams));
-                break;
-
-            case 7:
-            case 8:
-            case 9:
-                return (etgFunctionSize(nParams));
-                break;
-
-            default: 
-                break;
-        }
-    } 
-*/ // etgSpawnNewEffect
-/*
-    if (((etgfunctioncall *)opcode)->function == etgCreateEffects){
-        switch  (nParams+((etgfunctioncall *)opcode)->passThis){
-            case 6: 
-                etgCreateEffects(effect, ((etgfunctioncall *)opcode)->parameter[0].param,((etgfunctioncall *)opcode)->parameter[1].param,((etgfunctioncall *)opcode)->parameter[2].param,1, ((etgfunctioncall *)opcode)->parameter[4].param);
-                return (etgFunctionSize(nParams));
-                break;
-            case 7: 
-                etgCreateEffects(effect, ((etgfunctioncall *)opcode)->parameter[0].param,((etgfunctioncall *)opcode)->parameter[1].param,((etgfunctioncall *)opcode)->parameter[2].param,1, ((etgfunctioncall *)opcode)->parameter[4].param, ((etgfunctioncall *)opcode)->parameter[5].param);
-                return (etgFunctionSize(nParams));
-                break;
-            case 8: 
-                etgCreateEffects(effect, ((etgfunctioncall *)opcode)->parameter[0].param,((etgfunctioncall *)opcode)->parameter[1].param,((etgfunctioncall *)opcode)->parameter[2].param,1, ((etgfunctioncall *)opcode)->parameter[4].param, ((etgfunctioncall *)opcode)->parameter[5].param,((etgfunctioncall *)opcode)->parameter[6].param);
-                return (etgFunctionSize(nParams));
-                break;
-
-            case 9:
-            case 10:
-            case 11:
-                return (etgFunctionSize(nParams));
-                break;
-
-            default: 
-                break;
-        }
-    } 
-*/ //etgCreateEffects
 	while ((entry = &etgFunctionTable[currEntry++])->name != NULL)
 	{
 		if (entry->function == ((etgfunctioncall *)opcode)->function)
@@ -6099,23 +6042,10 @@ sdword etgFunctionCall(Effect *effect, struct etgeffectstatic *stat, ubyte *opco
                 isLabel = 0;
                 break;
             case EVT_ConstLabel:
-//                param = (udword)stat->constData + param;
                 param = (memsize)stat->constData + param;
                 isLabel = 1;
                 break;
-//            case EVT_Pointer:   
-//                param = effect->variable + param;
-//                if ( (memsize)((etgfunctioncall *)opcode)->parameter[index].paramptr != 0 ) {
-//                param = *((memsize*)(effect->variable + param));
-//                    param = (memsize)((etgfunctioncall *)opcode)->parameter[index].paramptr; 
-//                }
-//                else {
-//                    param = (memsize)((etgfunctioncall *)opcode)->parameter[index].paramptr; 
-//                }
-//                isLabel = 1;
-//                break;
             case EVT_VarLabel:
-//                param = (udword)effect->variable + param;
                 param = (memsize) effect->variable + param;
                 isLabel = 1;
                 break;
@@ -6166,21 +6096,16 @@ sdword etgFunctionCall(Effect *effect, struct etgeffectstatic *stat, ubyte *opco
 
     if ((memsize)((etgfunctioncall *)opcode)->function == (memsize) etgSpawnNewEffect){
 
-//        dbgMessagef("Function: %lx:%d   -> %s",((etgfunctioncall *)opcode)->function, nParams+((etgfunctioncall *)opcode)->passThis ,  stat->name);
-
         switch  (nParams+((etgfunctioncall *)opcode)->passThis){
             case 4: 
-//                dbgMessagef("etgSpawnNewEffect %lx,%lx,%lx,%lx", effect,intParam[1],1,intParam[3]);
                 etgSpawnNewEffect(effect, (etgeffectstatic *) intParam[1],1,intParam[3]);
                 return (etgFunctionSize(nParams));
                 break;
             case 5: 
-//                dbgMessagef("etgSpawnNewEffect %lx,%lx,%lx,%lx,%lx", effect,intParam[1],2,intParam[3],intParam[4]);
                 etgSpawnNewEffect(effect, (etgeffectstatic *) intParam[1],2,intParam[3],intParam[4]);
                 return (etgFunctionSize(nParams));
                 break;
             case 6: 
-//                dbgMessagef("etgSpawnNewEffect %lx,%lx,%lx,%lx,%lx,%lx", effect,intParam[1],3,intParam[3],intParam[4],intParam[5]);
                 etgSpawnNewEffect(effect, (etgeffectstatic *) intParam[1],3,intParam[3],intParam[4],intParam[5]);
                 return (etgFunctionSize(nParams));
                 break;
@@ -6192,24 +6117,20 @@ sdword etgFunctionCall(Effect *effect, struct etgeffectstatic *stat, ubyte *opco
                 break;
 
             default: 
-//                dbgMessagef("etgSpawnNewEffect %lx,%lx", effect,intParam[1],intParam[2]);
                 break;
         }
     } 
     if ((memsize)((etgfunctioncall *)opcode)->function == (memsize) etgCreateEffects){
         switch  (nParams+((etgfunctioncall *)opcode)->passThis){
             case 6: 
-//                dbgMessagef("etgCreateEffects %lx,%lx,%lx,%lx,%lx,%lx", effect,intParam[1],intParam[2],intParam[3],1,intParam[5]);
                 etgCreateEffects(effect, (etgeffectstatic *) intParam[1],intParam[2],intParam[3],1, intParam[5]);
                 return (etgFunctionSize(nParams));
                 break;
             case 7: 
-//                dbgMessagef("etgCreateEffects %lx,%lx,%lx,%lx,%lx,%lx,%lx", effect,intParam[1],intParam[2],intParam[3],2,intParam[5],intParam[6]);
                 etgCreateEffects(effect, (etgeffectstatic *) intParam[1],intParam[2],intParam[3],2, intParam[5], intParam[6]);
                 return (etgFunctionSize(nParams));
                 break;
             case 8: 
-//                dbgMessagef("etgCreateEffects %lx,%lx,%lx,%lx,%lx,%lx,%lx,%lx", effect,intParam[1],intParam[2],intParam[3],3,intParam[5],intParam[6],intParam[7]);
                 etgCreateEffects(effect, (etgeffectstatic *) intParam[1],intParam[2],intParam[3],3, intParam[5], intParam[6],intParam[7]);
                 return (etgFunctionSize(nParams));
                 break;
@@ -6221,7 +6142,6 @@ sdword etgFunctionCall(Effect *effect, struct etgeffectstatic *stat, ubyte *opco
                 break;
 
             default: 
-//                dbgMessagef("etgCreateEffects %lx,%lx,%lx,%lx,%lx", effect,intParam[1],intParam[2],intParam[3],intParam[4]);
                 break;
         }
     } 

--- a/src/Game/ETG.c
+++ b/src/Game/ETG.c
@@ -2830,7 +2830,7 @@ bool etgOpcodeScan(struct etgeffectstatic *stat, char *string, ubyte *dest, sdwo
             }
             //call the parsing function
             *destLength = etgParseTable[index].function(stat, dest, start, params, returnValue);
-            dbgAssertOrIgnore(*destLength < OPCODE_MAX && *destLength >= 0);
+            dbgAssertOrIgnore(0 <= *destLength && *destLength < OPCODE_MAX);
             return(TRUE);
         }
     }

--- a/src/Game/Types.c
+++ b/src/Game/Types.c
@@ -37,3 +37,8 @@ real32 SdwordToReal32(sdword a)
 {
  return (*(real32*)(&a));
 }
+
+real32 MemsizeToReal32(memsize a)
+{
+    return (*(real32 *)(&a));
+}

--- a/src/Game/Types.h
+++ b/src/Game/Types.h
@@ -121,6 +121,8 @@ real32 UdwordToReal32(udword a);
 
 real32 SdwordToReal32(sdword a);
 
+real32 MemsizeToReal32(memsize a);
+
 #define TreatAsUdword(x) (*((udword *)(&(x))))
 
 #define TreatAsReal32(x) (*((real32 *)(&(x))))

--- a/src/Game/wrap.h
+++ b/src/Game/wrap.h
@@ -2,7 +2,7 @@
 #define get_EVT_ConstLabel(n)	do_get_arg(effect, stat, opcode, n)
 #define get_EVT_VarLabel(n)	do_get_arg(effect, stat, opcode, n)
 #define get_EVT_Int(n)		do_get_arg(effect, stat, opcode, n)
-#define get_EVT_Float(n)	UdwordToReal32(do_get_arg(effect, stat, opcode, n))
+#define get_EVT_Float(n)	MemsizeToReal32(do_get_arg(effect, stat, opcode, n))
 #define get_EVT_RGB(n)		do_get_arg(effect, stat, opcode, n)
 #define get_EVT_RGBA(n)		do_get_arg(effect, stat, opcode, n)
 

--- a/src/Game/wrap.h
+++ b/src/Game/wrap.h
@@ -6,9 +6,9 @@
 #define get_EVT_RGB(n)		do_get_arg(effect, stat, opcode, n)
 #define get_EVT_RGBA(n)		do_get_arg(effect, stat, opcode, n)
 
-static inline udword do_get_arg(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode, udword index)
+static inline memsize do_get_arg(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode, udword index)
 {
-	udword param = opcode->parameter[index].param;
+	memsize param = opcode->parameter[index].param;
 
 	switch (opcode->parameter[index].type)	
 	{
@@ -18,13 +18,13 @@ static inline udword do_get_arg(Effect *effect, struct etgeffectstatic *stat, et
 			dbgAssertOrIgnore(FALSE);
 			break;
 		case EVT_ConstLabel:
-			param = (udword)stat->constData + param;
+			param = (memsize)stat->constData + param;
 			break;
 		case EVT_VarLabel:
-			param = (udword)effect->variable + param;
+			param = (memsize)effect->variable + param;
 			break;
 		default:
-			param = *((udword *)(effect->variable + param));
+			param = *((memsize *)(effect->variable + param));
 			break;
 	}
 	return param;

--- a/src/Game/wrap.h
+++ b/src/Game/wrap.h
@@ -32,64 +32,64 @@ static inline memsize do_get_arg(Effect *effect, struct etgeffectstatic *stat, e
 
 
 #define funcEntry0(name, ret, func) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	udword (*func_ptr)(void) = opcode->function; \
+	memsize (*func_ptr)(void) = opcode->function; \
 	return func_ptr(); \
 }
 
 #define funcEntry1(name, ret, func, p0) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
-	udword (*func_ptr)(_##p0) = (udword (*)(_##p0)) opcode->function; \
+	memsize (*func_ptr)(_##p0) = (memsize (*)(_##p0)) opcode->function; \
 	return func_ptr(var0); \
 }
 
 #define funcEntry2(name, ret, func, p0, p1) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
-	udword (*func_ptr)(_##p0, _##p1) = (udword (*)(_##p0, _##p1)) opcode->function; \
+	memsize (*func_ptr)(_##p0, _##p1) = (memsize (*)(_##p0, _##p1)) opcode->function; \
 	return func_ptr(var0, var1); \
 }
 
 #define funcEntry3(name, ret, func, p0, p1, p2) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
 	_##p2 var2 = get_##p2(2); \
-	udword (*func_ptr)(_##p0, _##p1, _##p2) = (udword (*)(_##p0, _##p1, _##p2)) opcode->function; \
+	memsize (*func_ptr)(_##p0, _##p1, _##p2) = (memsize (*)(_##p0, _##p1, _##p2)) opcode->function; \
 	return func_ptr(var0, var1, var2); \
 }
 
 #define funcEntry4(name, ret, func, p0, p1, p2, p3) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
 	_##p2 var2 = get_##p2(2); \
 	_##p3 var3 = get_##p3(3); \
-	udword (*func_ptr)(_##p0, _##p1, _##p2, _##p3) = (udword (*)(_##p0, _##p1, _##p2, _##p3)) opcode->function; \
+	memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3) = (memsize (*)(_##p0, _##p1, _##p2, _##p3)) opcode->function; \
 	return func_ptr(var0, var1, var2, var3); \
 }
 
 #define funcEntry5(name, ret, func, p0, p1, p2, p3, p4) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
 	_##p2 var2 = get_##p2(2); \
 	_##p3 var3 = get_##p3(3); \
 	_##p4 var4 = get_##p4(4); \
-	udword (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4) = (udword (*)(_##p0, _##p1, _##p2, _##p3, _##p4)) opcode->function; \
+	memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4) = (memsize (*)(_##p0, _##p1, _##p2, _##p3, _##p4)) opcode->function; \
 	return func_ptr(var0, var1, var2, var3, var4); \
 }
 
 #define funcEntry6(name, ret, func, p0, p1, p2, p3, p4, p5) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
@@ -97,12 +97,12 @@ udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall
 	_##p3 var3 = get_##p3(3); \
 	_##p4 var4 = get_##p4(4); \
 	_##p5 var5 = get_##p5(5); \
-	udword (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5) = (udword (*)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5)) opcode->function; \
+	memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5) = (memsize (*)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5)) opcode->function; \
 	return func_ptr(var0, var1, var2, var3, var4, var5); \
 }
 
 #define funcEntry7(name, ret, func, p0, p1, p2, p3, p4, p5, p6) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
@@ -111,12 +111,12 @@ udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall
 	_##p4 var4 = get_##p4(4); \
 	_##p5 var5 = get_##p5(5); \
 	_##p6 var6 = get_##p6(6); \
-	udword (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6) = (udword (*)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6)) opcode->function; \
+	memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6) = (memsize (*)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6)) opcode->function; \
 	return func_ptr(var0, var1, var2, var3, var4, var5, var6); \
 }
 
 #define funcEntry8(name, ret, func, p0, p1, p2, p3, p4, p5, p6, p7) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
@@ -126,71 +126,71 @@ udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall
 	_##p5 var5 = get_##p5(5); \
 	_##p6 var6 = get_##p6(6); \
 	_##p7 var7 = get_##p7(7); \
-	udword (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6,  _##p7) = (udword (*)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6,  _##p7)) opcode->function; \
+	memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6,  _##p7) = (memsize (*)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6,  _##p7)) opcode->function; \
 	return func_ptr(var0, var1, var2, var3, var4, var5, var6, var7); \
 }
 
 /**************************************************************************************/
 
 #define funcEntryThis0(name, ret, func) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	udword (*func_ptr)(void *) = (udword (*)(void *)) opcode->function; \
+	memsize (*func_ptr)(void *) = (memsize (*)(void *)) opcode->function; \
 	return func_ptr(effect); \
 }
 
 #define funcEntryThis1(name, ret, func, p0) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
-	udword (*func_ptr)(void *, _##p0) = (udword (*)(void *, _##p0)) opcode->function; \
+	memsize (*func_ptr)(void *, _##p0) = (memsize (*)(void *, _##p0)) opcode->function; \
 	return func_ptr(effect, var0); \
 }
 
 #define funcEntryThis2(name, ret, func, p0, p1) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
-	udword (*func_ptr)(void *, _##p0, _##p1) = (udword (*)(void *, _##p0, _##p1)) opcode->function; \
+	memsize (*func_ptr)(void *, _##p0, _##p1) = (memsize (*)(void *, _##p0, _##p1)) opcode->function; \
 	return func_ptr(effect, var0, var1); \
 }
 
 #define funcEntryThis3(name, ret, func, p0, p1, p2) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
 	_##p2 var2 = get_##p2(2); \
-	udword (*func_ptr)(void *, _##p0, _##p1, _##p2) = (udword (*)(void *, _##p0, _##p1, _##p2)) opcode->function; \
+	memsize (*func_ptr)(void *, _##p0, _##p1, _##p2) = (memsize (*)(void *, _##p0, _##p1, _##p2)) opcode->function; \
 	return func_ptr(effect, var0, var1, var2); \
 }
 
 #define funcEntryThis4(name, ret, func, p0, p1, p2, p3) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
 	_##p2 var2 = get_##p2(2); \
 	_##p3 var3 = get_##p3(3); \
-	udword (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3) = (udword (*)(void *, _##p0, _##p1, _##p2, _##p3)) opcode->function; \
+	memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3)) opcode->function; \
 	return func_ptr(effect, var0, var1, var2, var3); \
 }
 
 #define funcEntryThis5(name, ret, func, p0, p1, p2, p3, p4) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
 	_##p2 var2 = get_##p2(2); \
 	_##p3 var3 = get_##p3(3); \
 	_##p4 var4 = get_##p4(4); \
-	udword (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4) = (udword (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4)) opcode->function; \
+	memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4)) opcode->function; \
 	return func_ptr(effect, var0, var1, var2, var3, var4); \
 }
 
 #define funcEntryThis6(name, ret, func, p0, p1, p2, p3, p4, p5) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
@@ -198,12 +198,12 @@ udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall
 	_##p3 var3 = get_##p3(3); \
 	_##p4 var4 = get_##p4(4); \
 	_##p5 var5 = get_##p5(5); \
-	udword (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5) = (udword (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5)) opcode->function; \
+	memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5)) opcode->function; \
 	return func_ptr(effect, var0, var1, var2, var3, var4, var5); \
 }
 
 #define funcEntryThis7(name, ret, func, p0, p1, p2, p3, p4, p5, p6) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
@@ -212,12 +212,12 @@ udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall
 	_##p4 var4 = get_##p4(4); \
 	_##p5 var5 = get_##p5(5); \
 	_##p6 var6 = get_##p6(6); \
-	udword (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6) = (udword (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6)) opcode->function; \
+	memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6)) opcode->function; \
 	return func_ptr(effect, var0, var1, var2, var3, var4, var5, var6); \
 }
 
 #define funcEntryThis8(name, ret, func, p0, p1, p2, p3, p4, p5, p6, p7) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
@@ -227,45 +227,45 @@ udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall
 	_##p5 var5 = get_##p5(5); \
 	_##p6 var6 = get_##p6(6); \
 	_##p7 var7 = get_##p7(7); \
-	udword (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6, _##p7) = (udword (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6, _##p7)) opcode->function; \
+	memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6, _##p7) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6, _##p7)) opcode->function; \
 	return func_ptr(effect, var0, var1, var2, var3, var4, var5, var6, var7); \
 }
 
 /************************************************/
 
 #define funcEntryR1(name, ret, func, p0, resolve) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
-	udword (*func_ptr)(_##p0) = (udword (*)(_##p0)) opcode->function; \
+	memsize (*func_ptr)(_##p0) = (memsize (*)(_##p0)) opcode->function; \
 	return func_ptr(var0); \
 }
 
 #define funcEntryR2(name, ret, func, p0, p1, resolve) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
-	udword (*func_ptr)(_##p0, _##p1) = (udword (*)(_##p0, _##p1)) opcode->function; \
+	memsize (*func_ptr)(_##p0, _##p1) = (memsize (*)(_##p0, _##p1)) opcode->function; \
 	return func_ptr(var0, var1); \
 }
 
 /************************************************/
 
 #define funcEntryThisR1(name, ret, func, p0, resolve)  \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
-	udword (*func_ptr)(void *, _##p0) = (udword (*)(void *, _##p0)) opcode->function; \
+	memsize (*func_ptr)(void *, _##p0) = (memsize (*)(void *, _##p0)) opcode->function; \
 	return func_ptr(effect, var0); \
 }
 
 #define funcEntryThisR2(name, ret, func, p0, p1, resolve) \
-udword	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
 	_##p0 var0 = get_##p0(0); \
 	_##p1 var1 = get_##p1(1); \
-	udword (*func_ptr)(void *, _##p0, _##p1) = (udword (*)(void *, _##p0, _##p1)) opcode->function; \
+	memsize (*func_ptr)(void *, _##p0, _##p1) = (memsize (*)(void *, _##p0, _##p1)) opcode->function; \
 	return func_ptr(effect, var0, var1); \
 }
 

--- a/src/Game/wrap.h
+++ b/src/Game/wrap.h
@@ -1,271 +1,271 @@
-#define get_EVT_Constant(n)	do_get_arg(effect, stat, opcode, n)
-#define get_EVT_ConstLabel(n)	do_get_arg(effect, stat, opcode, n)
-#define get_EVT_VarLabel(n)	do_get_arg(effect, stat, opcode, n)
-#define get_EVT_Int(n)		do_get_arg(effect, stat, opcode, n)
-#define get_EVT_Float(n)	MemsizeToReal32(do_get_arg(effect, stat, opcode, n))
-#define get_EVT_RGB(n)		do_get_arg(effect, stat, opcode, n)
-#define get_EVT_RGBA(n)		do_get_arg(effect, stat, opcode, n)
+#define get_EVT_Constant(n)      do_get_arg(effect, stat, opcode, n)
+#define get_EVT_ConstLabel(n)    do_get_arg(effect, stat, opcode, n)
+#define get_EVT_VarLabel(n)      do_get_arg(effect, stat, opcode, n)
+#define get_EVT_Int(n)           do_get_arg(effect, stat, opcode, n)
+#define get_EVT_Float(n)         MemsizeToReal32(do_get_arg(effect, stat, opcode, n))
+#define get_EVT_RGB(n)           do_get_arg(effect, stat, opcode, n)
+#define get_EVT_RGBA(n)          do_get_arg(effect, stat, opcode, n)
 
 static inline memsize do_get_arg(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode, udword index)
 {
-	memsize param = opcode->parameter[index].param;
+    memsize param = opcode->parameter[index].param;
 
-	switch (opcode->parameter[index].type)	
-	{
-		case EVT_Constant:
-			break;
-		case EVT_Label:
-			dbgAssertOrIgnore(FALSE);
-			break;
-		case EVT_ConstLabel:
-			param = (memsize)stat->constData + param;
-			break;
-		case EVT_VarLabel:
-			param = (memsize)effect->variable + param;
-			break;
-		default:
-			param = *((memsize *)(effect->variable + param));
-			break;
-	}
-	return param;
+    switch (opcode->parameter[index].type)    
+    {
+        case EVT_Constant:
+            break;
+        case EVT_Label:
+            dbgAssertOrIgnore(FALSE);
+            break;
+        case EVT_ConstLabel:
+            param = (memsize)stat->constData + param;
+            break;
+        case EVT_VarLabel:
+            param = (memsize)effect->variable + param;
+            break;
+        default:
+            param = *((memsize *)(effect->variable + param));
+            break;
+    }
+    return param;
 }
 
 
 #define funcEntry0(name, ret, func) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	memsize (*func_ptr)(void) = opcode->function; \
-	return func_ptr(); \
+    memsize (*func_ptr)(void) = opcode->function; \
+    return func_ptr(); \
 }
 
 #define funcEntry1(name, ret, func, p0) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	memsize (*func_ptr)(_##p0) = (memsize (*)(_##p0)) opcode->function; \
-	return func_ptr(var0); \
+    _##p0 var0 = get_##p0(0); \
+    memsize (*func_ptr)(_##p0) = (memsize (*)(_##p0)) opcode->function; \
+    return func_ptr(var0); \
 }
 
 #define funcEntry2(name, ret, func, p0, p1) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	memsize (*func_ptr)(_##p0, _##p1) = (memsize (*)(_##p0, _##p1)) opcode->function; \
-	return func_ptr(var0, var1); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    memsize (*func_ptr)(_##p0, _##p1) = (memsize (*)(_##p0, _##p1)) opcode->function; \
+    return func_ptr(var0, var1); \
 }
 
 #define funcEntry3(name, ret, func, p0, p1, p2) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	_##p2 var2 = get_##p2(2); \
-	memsize (*func_ptr)(_##p0, _##p1, _##p2) = (memsize (*)(_##p0, _##p1, _##p2)) opcode->function; \
-	return func_ptr(var0, var1, var2); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    _##p2 var2 = get_##p2(2); \
+    memsize (*func_ptr)(_##p0, _##p1, _##p2) = (memsize (*)(_##p0, _##p1, _##p2)) opcode->function; \
+    return func_ptr(var0, var1, var2); \
 }
 
 #define funcEntry4(name, ret, func, p0, p1, p2, p3) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	_##p2 var2 = get_##p2(2); \
-	_##p3 var3 = get_##p3(3); \
-	memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3) = (memsize (*)(_##p0, _##p1, _##p2, _##p3)) opcode->function; \
-	return func_ptr(var0, var1, var2, var3); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    _##p2 var2 = get_##p2(2); \
+    _##p3 var3 = get_##p3(3); \
+    memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3) = (memsize (*)(_##p0, _##p1, _##p2, _##p3)) opcode->function; \
+    return func_ptr(var0, var1, var2, var3); \
 }
 
 #define funcEntry5(name, ret, func, p0, p1, p2, p3, p4) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	_##p2 var2 = get_##p2(2); \
-	_##p3 var3 = get_##p3(3); \
-	_##p4 var4 = get_##p4(4); \
-	memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4) = (memsize (*)(_##p0, _##p1, _##p2, _##p3, _##p4)) opcode->function; \
-	return func_ptr(var0, var1, var2, var3, var4); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    _##p2 var2 = get_##p2(2); \
+    _##p3 var3 = get_##p3(3); \
+    _##p4 var4 = get_##p4(4); \
+    memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4) = (memsize (*)(_##p0, _##p1, _##p2, _##p3, _##p4)) opcode->function; \
+    return func_ptr(var0, var1, var2, var3, var4); \
 }
 
 #define funcEntry6(name, ret, func, p0, p1, p2, p3, p4, p5) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	_##p2 var2 = get_##p2(2); \
-	_##p3 var3 = get_##p3(3); \
-	_##p4 var4 = get_##p4(4); \
-	_##p5 var5 = get_##p5(5); \
-	memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5) = (memsize (*)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5)) opcode->function; \
-	return func_ptr(var0, var1, var2, var3, var4, var5); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    _##p2 var2 = get_##p2(2); \
+    _##p3 var3 = get_##p3(3); \
+    _##p4 var4 = get_##p4(4); \
+    _##p5 var5 = get_##p5(5); \
+    memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5) = (memsize (*)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5)) opcode->function; \
+    return func_ptr(var0, var1, var2, var3, var4, var5); \
 }
 
 #define funcEntry7(name, ret, func, p0, p1, p2, p3, p4, p5, p6) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	_##p2 var2 = get_##p2(2); \
-	_##p3 var3 = get_##p3(3); \
-	_##p4 var4 = get_##p4(4); \
-	_##p5 var5 = get_##p5(5); \
-	_##p6 var6 = get_##p6(6); \
-	memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6) = (memsize (*)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6)) opcode->function; \
-	return func_ptr(var0, var1, var2, var3, var4, var5, var6); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    _##p2 var2 = get_##p2(2); \
+    _##p3 var3 = get_##p3(3); \
+    _##p4 var4 = get_##p4(4); \
+    _##p5 var5 = get_##p5(5); \
+    _##p6 var6 = get_##p6(6); \
+    memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6) = (memsize (*)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6)) opcode->function; \
+    return func_ptr(var0, var1, var2, var3, var4, var5, var6); \
 }
 
 #define funcEntry8(name, ret, func, p0, p1, p2, p3, p4, p5, p6, p7) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	_##p2 var2 = get_##p2(2); \
-	_##p3 var3 = get_##p3(3); \
-	_##p4 var4 = get_##p4(4); \
-	_##p5 var5 = get_##p5(5); \
-	_##p6 var6 = get_##p6(6); \
-	_##p7 var7 = get_##p7(7); \
-	memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6,  _##p7) = (memsize (*)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6,  _##p7)) opcode->function; \
-	return func_ptr(var0, var1, var2, var3, var4, var5, var6, var7); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    _##p2 var2 = get_##p2(2); \
+    _##p3 var3 = get_##p3(3); \
+    _##p4 var4 = get_##p4(4); \
+    _##p5 var5 = get_##p5(5); \
+    _##p6 var6 = get_##p6(6); \
+    _##p7 var7 = get_##p7(7); \
+    memsize (*func_ptr)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6,  _##p7) = (memsize (*)(_##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6,  _##p7)) opcode->function; \
+    return func_ptr(var0, var1, var2, var3, var4, var5, var6, var7); \
 }
 
 /**************************************************************************************/
 
 #define funcEntryThis0(name, ret, func) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	memsize (*func_ptr)(void *) = (memsize (*)(void *)) opcode->function; \
-	return func_ptr(effect); \
+    memsize (*func_ptr)(void *) = (memsize (*)(void *)) opcode->function; \
+    return func_ptr(effect); \
 }
 
 #define funcEntryThis1(name, ret, func, p0) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	memsize (*func_ptr)(void *, _##p0) = (memsize (*)(void *, _##p0)) opcode->function; \
-	return func_ptr(effect, var0); \
+    _##p0 var0 = get_##p0(0); \
+    memsize (*func_ptr)(void *, _##p0) = (memsize (*)(void *, _##p0)) opcode->function; \
+    return func_ptr(effect, var0); \
 }
 
 #define funcEntryThis2(name, ret, func, p0, p1) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	memsize (*func_ptr)(void *, _##p0, _##p1) = (memsize (*)(void *, _##p0, _##p1)) opcode->function; \
-	return func_ptr(effect, var0, var1); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    memsize (*func_ptr)(void *, _##p0, _##p1) = (memsize (*)(void *, _##p0, _##p1)) opcode->function; \
+    return func_ptr(effect, var0, var1); \
 }
 
 #define funcEntryThis3(name, ret, func, p0, p1, p2) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	_##p2 var2 = get_##p2(2); \
-	memsize (*func_ptr)(void *, _##p0, _##p1, _##p2) = (memsize (*)(void *, _##p0, _##p1, _##p2)) opcode->function; \
-	return func_ptr(effect, var0, var1, var2); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    _##p2 var2 = get_##p2(2); \
+    memsize (*func_ptr)(void *, _##p0, _##p1, _##p2) = (memsize (*)(void *, _##p0, _##p1, _##p2)) opcode->function; \
+    return func_ptr(effect, var0, var1, var2); \
 }
 
 #define funcEntryThis4(name, ret, func, p0, p1, p2, p3) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	_##p2 var2 = get_##p2(2); \
-	_##p3 var3 = get_##p3(3); \
-	memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3)) opcode->function; \
-	return func_ptr(effect, var0, var1, var2, var3); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    _##p2 var2 = get_##p2(2); \
+    _##p3 var3 = get_##p3(3); \
+    memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3)) opcode->function; \
+    return func_ptr(effect, var0, var1, var2, var3); \
 }
 
 #define funcEntryThis5(name, ret, func, p0, p1, p2, p3, p4) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	_##p2 var2 = get_##p2(2); \
-	_##p3 var3 = get_##p3(3); \
-	_##p4 var4 = get_##p4(4); \
-	memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4)) opcode->function; \
-	return func_ptr(effect, var0, var1, var2, var3, var4); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    _##p2 var2 = get_##p2(2); \
+    _##p3 var3 = get_##p3(3); \
+    _##p4 var4 = get_##p4(4); \
+    memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4)) opcode->function; \
+    return func_ptr(effect, var0, var1, var2, var3, var4); \
 }
 
 #define funcEntryThis6(name, ret, func, p0, p1, p2, p3, p4, p5) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	_##p2 var2 = get_##p2(2); \
-	_##p3 var3 = get_##p3(3); \
-	_##p4 var4 = get_##p4(4); \
-	_##p5 var5 = get_##p5(5); \
-	memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5)) opcode->function; \
-	return func_ptr(effect, var0, var1, var2, var3, var4, var5); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    _##p2 var2 = get_##p2(2); \
+    _##p3 var3 = get_##p3(3); \
+    _##p4 var4 = get_##p4(4); \
+    _##p5 var5 = get_##p5(5); \
+    memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5)) opcode->function; \
+    return func_ptr(effect, var0, var1, var2, var3, var4, var5); \
 }
 
 #define funcEntryThis7(name, ret, func, p0, p1, p2, p3, p4, p5, p6) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	_##p2 var2 = get_##p2(2); \
-	_##p3 var3 = get_##p3(3); \
-	_##p4 var4 = get_##p4(4); \
-	_##p5 var5 = get_##p5(5); \
-	_##p6 var6 = get_##p6(6); \
-	memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6)) opcode->function; \
-	return func_ptr(effect, var0, var1, var2, var3, var4, var5, var6); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    _##p2 var2 = get_##p2(2); \
+    _##p3 var3 = get_##p3(3); \
+    _##p4 var4 = get_##p4(4); \
+    _##p5 var5 = get_##p5(5); \
+    _##p6 var6 = get_##p6(6); \
+    memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6)) opcode->function; \
+    return func_ptr(effect, var0, var1, var2, var3, var4, var5, var6); \
 }
 
 #define funcEntryThis8(name, ret, func, p0, p1, p2, p3, p4, p5, p6, p7) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	_##p2 var2 = get_##p2(2); \
-	_##p3 var3 = get_##p3(3); \
-	_##p4 var4 = get_##p4(4); \
-	_##p5 var5 = get_##p5(5); \
-	_##p6 var6 = get_##p6(6); \
-	_##p7 var7 = get_##p7(7); \
-	memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6, _##p7) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6, _##p7)) opcode->function; \
-	return func_ptr(effect, var0, var1, var2, var3, var4, var5, var6, var7); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    _##p2 var2 = get_##p2(2); \
+    _##p3 var3 = get_##p3(3); \
+    _##p4 var4 = get_##p4(4); \
+    _##p5 var5 = get_##p5(5); \
+    _##p6 var6 = get_##p6(6); \
+    _##p7 var7 = get_##p7(7); \
+    memsize (*func_ptr)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6, _##p7) = (memsize (*)(void *, _##p0, _##p1, _##p2, _##p3, _##p4, _##p5, _##p6, _##p7)) opcode->function; \
+    return func_ptr(effect, var0, var1, var2, var3, var4, var5, var6, var7); \
 }
 
 /************************************************/
 
 #define funcEntryR1(name, ret, func, p0, resolve) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	memsize (*func_ptr)(_##p0) = (memsize (*)(_##p0)) opcode->function; \
-	return func_ptr(var0); \
+    _##p0 var0 = get_##p0(0); \
+    memsize (*func_ptr)(_##p0) = (memsize (*)(_##p0)) opcode->function; \
+    return func_ptr(var0); \
 }
 
 #define funcEntryR2(name, ret, func, p0, p1, resolve) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	memsize (*func_ptr)(_##p0, _##p1) = (memsize (*)(_##p0, _##p1)) opcode->function; \
-	return func_ptr(var0, var1); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    memsize (*func_ptr)(_##p0, _##p1) = (memsize (*)(_##p0, _##p1)) opcode->function; \
+    return func_ptr(var0, var1); \
 }
 
 /************************************************/
 
 #define funcEntryThisR1(name, ret, func, p0, resolve)  \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	memsize (*func_ptr)(void *, _##p0) = (memsize (*)(void *, _##p0)) opcode->function; \
-	return func_ptr(effect, var0); \
+    _##p0 var0 = get_##p0(0); \
+    memsize (*func_ptr)(void *, _##p0) = (memsize (*)(void *, _##p0)) opcode->function; \
+    return func_ptr(effect, var0); \
 }
 
 #define funcEntryThisR2(name, ret, func, p0, p1, resolve) \
-memsize	wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
+memsize wrap_##func(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode) \
 { \
-	_##p0 var0 = get_##p0(0); \
-	_##p1 var1 = get_##p1(1); \
-	memsize (*func_ptr)(void *, _##p0, _##p1) = (memsize (*)(void *, _##p0, _##p1)) opcode->function; \
-	return func_ptr(effect, var0, var1); \
+    _##p0 var0 = get_##p0(0); \
+    _##p1 var1 = get_##p1(1); \
+    memsize (*func_ptr)(void *, _##p0, _##p1) = (memsize (*)(void *, _##p0, _##p1)) opcode->function; \
+    return func_ptr(effect, var0, var1); \
 }
 

--- a/src/Game/wrap.h
+++ b/src/Game/wrap.h
@@ -10,23 +10,23 @@ static inline udword do_get_arg(Effect *effect, struct etgeffectstatic *stat, et
 {
 	udword param = opcode->parameter[index].param;
 
-        switch (opcode->parameter[index].type)	
-        {
-            case EVT_Constant:
-                break;
-            case EVT_Label:
-                dbgAssertOrIgnore(FALSE);
-                break;
-            case EVT_ConstLabel:
-                param = (udword)stat->constData + param;
-                break;
-            case EVT_VarLabel:
-                param = (udword)effect->variable + param;
-                break;
-            default:
-                param = *((udword *)(effect->variable + param));
-                break;
-        }
+	switch (opcode->parameter[index].type)	
+	{
+		case EVT_Constant:
+			break;
+		case EVT_Label:
+			dbgAssertOrIgnore(FALSE);
+			break;
+		case EVT_ConstLabel:
+			param = (udword)stat->constData + param;
+			break;
+		case EVT_VarLabel:
+			param = (udword)effect->variable + param;
+			break;
+		default:
+			param = *((udword *)(effect->variable + param));
+			break;
+	}
 	return param;
 }
 

--- a/src/Game/wrap_types.h
+++ b/src/Game/wrap_types.h
@@ -1,6 +1,6 @@
-#define _EVT_Void                    udword
-#define _EVT_Int                     udword
+#define _EVT_Void                    memsize
+#define _EVT_Int                     memsize
 #define _EVT_Float                   real32
-#define _EVT_RGB                     udword
-#define _EVT_RGBA                    udword
-#define _EVT_ConstLabel		     udword
+#define _EVT_RGB                     memsize
+#define _EVT_RGBA                    memsize
+#define _EVT_ConstLabel              memsize

--- a/src/Game/wrapped_unlisted_functions.h
+++ b/src/Game/wrapped_unlisted_functions.h
@@ -56,47 +56,24 @@ memsize etgSpawnNewEffect(Effect *effect, etgeffectstatic *stat, sdword nParams,
 udword wrap_etgSpawnNewEffect(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
 {
 	udword nParams     = opcode->nParameters;
+	memsize intParam[8] = {0,0,0,0,0,0,0,0};
 
-	memsize param       = 0;
-	udword intParam[8] = {0,0,0,0,0,0,0,0};
-//	memsize floatParam[8] = {0,0,0,0,0,0,0,0};
-
-	udword i;
-
-	for (i=0;i<opcode->nParameters;i++)
+	for (udword i = 0; i < nParams; i++)
 	{
 		intParam[i] = get_arg(i);
 	}
 
-//        dbgMessagef("Function: %lx:%d   -> %s",((etgfunctioncall *)opcode)->function, nParams+((etgfunctioncall *)opcode)->passThis ,  stat->name);
+    etgSpawnNewEffect(
+        effect,
+        (etgeffectstatic *) intParam[0],
+        (sdword) intParam[1], // nParams
+        intParam[2],
+        intParam[3],
+        intParam[4],
+        intParam[5],
+        intParam[6],
+        intParam[7]);
 
-        switch  (nParams+((etgfunctioncall *)opcode)->passThis){
-            case 4: 
-//                dbgMessagef("etgSpawnNewEffect %lx,%lx,%lx,%lx", effect,intParam[1],1,intParam[3]);
-                etgSpawnNewEffect(effect, intParam[0],1,intParam[2]);
-                return (etgFunctionSize(nParams));
-                break;
-            case 5: 
-//                dbgMessagef("etgSpawnNewEffect %lx,%lx,%lx,%lx,%lx", effect,intParam[1],2,intParam[3],intParam[4]);
-                etgSpawnNewEffect(effect, intParam[0],2,intParam[2],intParam[3]);
-                return (etgFunctionSize(nParams));
-                break;
-            case 6: 
-//                dbgMessagef("etgSpawnNewEffect %lx,%lx,%lx,%lx,%lx,%lx", effect,intParam[1],3,intParam[3],intParam[4],intParam[5]);
-                etgSpawnNewEffect(effect, intParam[0],3,intParam[2],intParam[3],intParam[4]);
-                return (etgFunctionSize(nParams));
-                break;
-
-            case 7:
-            case 8:
-            case 9:
-                return (etgFunctionSize(nParams));
-                break;
-
-            default: 
-//                dbgMessagef("etgSpawnNewEffect %lx,%lx", effect,intParam[1],intParam[2]);
-                break;
-        }
 	return(etgFunctionSize(nParams));
 }
 
@@ -106,44 +83,24 @@ void etgCreateEffects(Effect *effect, etgeffectstatic *stat, sdword number, sdwo
 udword wrap_etgCreateEffects(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
 {
 	udword nParams     = opcode->nParameters;
+	memsize intParam[8] = {0,0,0,0,0,0,0,0};
 
-	memsize param       = 0;
-	udword intParam[8] = {0,0,0,0,0,0,0,0};
-
-	udword i;
-
-	for (i=0;i<opcode->nParameters;i++)
+	for (udword i = 0; i < nParams; i++)
 	{
 		intParam[i] = get_arg(i);
 	}
 
-        switch  (nParams+((etgfunctioncall *)opcode)->passThis){
-            case 6: 
-//                dbgMessagef("etgCreateEffects %lx,%lx,%lx,%lx,%lx,%lx", effect,intParam[1],intParam[2],intParam[3],1,intParam[5]);
-                etgCreateEffects(effect, intParam[0],intParam[1],intParam[2],1, intParam[3]);
-                return (etgFunctionSize(nParams));
-                break;
-            case 7: 
-//                dbgMessagef("etgCreateEffects %lx,%lx,%lx,%lx,%lx,%lx,%lx", effect,intParam[1],intParam[2],intParam[3],2,intParam[5],intParam[6]);
-                etgCreateEffects(effect, intParam[0],intParam[1],intParam[2],2, intParam[4], intParam[5]);
-                return (etgFunctionSize(nParams));
-                break;
-            case 8: 
-//                dbgMessagef("etgCreateEffects %lx,%lx,%lx,%lx,%lx,%lx,%lx,%lx", effect,intParam[1],intParam[2],intParam[3],3,intParam[5],intParam[6],intParam[7]);
-                etgCreateEffects(effect, intParam[0],intParam[1],intParam[2],3, intParam[4], intParam[5], intParam[6]);
-                return (etgFunctionSize(nParams));
-                break;
+    etgCreateEffects(
+        effect,
+        (etgeffectstatic *) intParam[0],
+        (sdword) intParam[1],
+        (sdword) intParam[2],
+        (sdword) intParam[3], // nParams
+        intParam[4],
+        intParam[5],
+        intParam[6],
+        intParam[7]);
 
-            case 9:
-            case 10:
-            case 11:
-                return (etgFunctionSize(nParams));
-                break;
-
-            default: 
-//                dbgMessagef("etgCreateEffects %lx,%lx,%lx,%lx,%lx", effect,intParam[1],intParam[2],intParam[3],intParam[4]);
-                break;
-        }
 	return(etgFunctionSize(nParams));
 }
 

--- a/src/Game/wrapped_unlisted_functions.h
+++ b/src/Game/wrapped_unlisted_functions.h
@@ -18,15 +18,15 @@ void partModifyTexture(psysPtr psys, trhandle tex, udword u0, udword v0, udword 
 
 memsize wrap_partModifyTexture(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
-    udword var0 = do_get_arg(effect, stat, opcode, 0);
-    udword var1 = do_get_arg(effect, stat, opcode, 1);
-    udword var2 = do_get_arg(effect, stat, opcode, 2);
-    udword var3 = do_get_arg(effect, stat, opcode, 3);
-    udword var4 = do_get_arg(effect, stat, opcode, 4);
-    udword var5 = do_get_arg(effect, stat, opcode, 5);
-    memsize (*func_ptr)(udword, udword, udword, udword, udword, udword) = (memsize(*)(udword, udword, udword, udword, udword, udword))opcode->function;
+    partModifyTexture(
+        get_arg(0),
+        get_arg(1),
+        get_arg(2),
+        get_arg(3),
+        get_arg(4),
+        get_arg(5));
 
-    return func_ptr(var0, var1, var2, var3, var4, var5);
+    return 0;
 }
 
 void partSetMeshdata(meshdata *m);

--- a/src/Game/wrapped_unlisted_functions.h
+++ b/src/Game/wrapped_unlisted_functions.h
@@ -5,11 +5,11 @@ void partSetTrHandle(trhandle t, udword u0, udword v0, udword u1, udword v1);
 memsize wrap_partSetTrHandle(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
     partSetTrHandle(
-        get_arg(0),
-        get_arg(1),
-        get_arg(2),
-        get_arg(3),
-        get_arg(4));
+        (trhandle)get_arg(0),
+        (udword)get_arg(1),
+        (udword)get_arg(2),
+        (udword)get_arg(3),
+        (udword)get_arg(4));
 
     return 0;
 }
@@ -19,12 +19,12 @@ void partModifyTexture(psysPtr psys, trhandle tex, udword u0, udword v0, udword 
 memsize wrap_partModifyTexture(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
     partModifyTexture(
-        get_arg(0),
-        get_arg(1),
-        get_arg(2),
-        get_arg(3),
-        get_arg(4),
-        get_arg(5));
+        (psysPtr)get_arg(0),
+        (trhandle)get_arg(1),
+        (udword)get_arg(2),
+        (udword)get_arg(3),
+        (udword)get_arg(4),
+        (udword)get_arg(5));
 
     return 0;
 }
@@ -33,7 +33,7 @@ void partSetMeshdata(meshdata *m);
 
 memsize wrap_partSetMeshdata(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
-    partSetMeshdata(get_arg(0));
+    partSetMeshdata((meshdata *)get_arg(0));
 
     return 0;
 }
@@ -42,7 +42,7 @@ void etgCreateCallbackSetup(Effect *effect, sdword codeOffset);
 
 memsize wrap_etgCreateCallbackSetup(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
-    etgCreateCallbackSetup(effect, get_arg(0));
+    etgCreateCallbackSetup(effect, (sdword)get_arg(0));
 
     return 0;
 }

--- a/src/Game/wrapped_unlisted_functions.h
+++ b/src/Game/wrapped_unlisted_functions.h
@@ -1,17 +1,15 @@
 #define get_arg(n) do_get_arg(effect, stat, opcode, n)
 
-#define memsize udword
-
 void partSetTrHandle(trhandle t, udword u0, udword v0, udword u1, udword v1);
 
-udword wrap_partSetTrHandle(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
+memsize wrap_partSetTrHandle(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
 {
 	udword var0 = do_get_arg(effect, stat, opcode, 0);
 	udword var1 = do_get_arg(effect, stat, opcode, 1);
 	udword var2 = do_get_arg(effect, stat, opcode, 2);
 	udword var3 = do_get_arg(effect, stat, opcode, 3);
 	udword var4 = do_get_arg(effect, stat, opcode, 4);
-	udword (*func_ptr)(udword, udword, udword, udword, udword) = (udword (*)(udword, udword, udword, udword, udword)) opcode->function;
+	memsize (*func_ptr)(udword, udword, udword, udword, udword) = (memsize (*)(udword, udword, udword, udword, udword)) opcode->function;
 
 	return func_ptr(var0, var1, var2, var3, var4);
 }
@@ -19,7 +17,7 @@ udword wrap_partSetTrHandle(Effect *effect, struct etgeffectstatic *stat ,etgfun
 
 void partModifyTexture(psysPtr psys, trhandle tex, udword u0, udword v0, udword u1, udword v1);
 
-udword wrap_partModifyTexture(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
+memsize wrap_partModifyTexture(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
 {
 	udword var0 = do_get_arg(effect, stat, opcode, 0);
 	udword var1 = do_get_arg(effect, stat, opcode, 1);
@@ -27,27 +25,27 @@ udword wrap_partModifyTexture(Effect *effect, struct etgeffectstatic *stat ,etgf
 	udword var3 = do_get_arg(effect, stat, opcode, 3);
 	udword var4 = do_get_arg(effect, stat, opcode, 4);
 	udword var5 = do_get_arg(effect, stat, opcode, 5);
-	udword (*func_ptr)(udword, udword, udword, udword, udword, udword) = (udword (*)(udword, udword, udword, udword, udword, udword)) opcode->function;
+	memsize (*func_ptr)(udword, udword, udword, udword, udword, udword) = (memsize (*)(udword, udword, udword, udword, udword, udword)) opcode->function;
 
 	return func_ptr(var0, var1, var2, var3, var4, var5);
 }
 
 void partSetMeshdata(meshdata *m);
 
-udword wrap_partSetMeshdata(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
+memsize wrap_partSetMeshdata(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
 {
 	udword var0 = do_get_arg(effect, stat, opcode, 0);
-	udword (*func_ptr)(udword) = (udword (*)(udword)) opcode->function;
+	memsize (*func_ptr)(udword) = (memsize (*)(udword)) opcode->function;
 
 	return func_ptr(var0);
 }
 
 void etgCreateCallbackSetup(Effect *effect, sdword codeOffset);
 
-udword wrap_etgCreateCallbackSetup(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
+memsize wrap_etgCreateCallbackSetup(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
 {
 	udword var0 = do_get_arg(effect, stat, opcode, 0);
-	udword (*func_ptr)(Effect *, udword) = (udword (*)(Effect *, udword)) opcode->function;
+	memsize (*func_ptr)(Effect *, udword) = (memsize (*)(Effect *, udword)) opcode->function;
 
 	return func_ptr(effect, var0);
 }

--- a/src/Game/wrapped_unlisted_functions.h
+++ b/src/Game/wrapped_unlisted_functions.h
@@ -33,20 +33,18 @@ void partSetMeshdata(meshdata *m);
 
 memsize wrap_partSetMeshdata(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
-    udword var0 = do_get_arg(effect, stat, opcode, 0);
-    memsize (*func_ptr)(udword) = (memsize(*)(udword))opcode->function;
+    partSetMeshdata(get_arg(0));
 
-    return func_ptr(var0);
+    return 0;
 }
 
 void etgCreateCallbackSetup(Effect *effect, sdword codeOffset);
 
 memsize wrap_etgCreateCallbackSetup(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
-    udword var0 = do_get_arg(effect, stat, opcode, 0);
-    memsize (*func_ptr)(Effect *, udword) = (memsize(*)(Effect *, udword))opcode->function;
+    etgCreateCallbackSetup(effect, get_arg(0));
 
-    return func_ptr(effect, var0);
+    return 0;
 }
 
 memsize etgSpawnNewEffect(Effect *effect, etgeffectstatic *stat, sdword nParams, ...);

--- a/src/Game/wrapped_unlisted_functions.h
+++ b/src/Game/wrapped_unlisted_functions.h
@@ -4,14 +4,14 @@ void partSetTrHandle(trhandle t, udword u0, udword v0, udword u1, udword v1);
 
 memsize wrap_partSetTrHandle(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
-    udword var0 = do_get_arg(effect, stat, opcode, 0);
-    udword var1 = do_get_arg(effect, stat, opcode, 1);
-    udword var2 = do_get_arg(effect, stat, opcode, 2);
-    udword var3 = do_get_arg(effect, stat, opcode, 3);
-    udword var4 = do_get_arg(effect, stat, opcode, 4);
-    memsize (*func_ptr)(udword, udword, udword, udword, udword) = (memsize(*)(udword, udword, udword, udword, udword))opcode->function;
+    partSetTrHandle(
+        get_arg(0),
+        get_arg(1),
+        get_arg(2),
+        get_arg(3),
+        get_arg(4));
 
-    return func_ptr(var0, var1, var2, var3, var4);
+    return 0;
 }
 
 void partModifyTexture(psysPtr psys, trhandle tex, udword u0, udword v0, udword u1, udword v1);

--- a/src/Game/wrapped_unlisted_functions.h
+++ b/src/Game/wrapped_unlisted_functions.h
@@ -2,71 +2,69 @@
 
 void partSetTrHandle(trhandle t, udword u0, udword v0, udword u1, udword v1);
 
-memsize wrap_partSetTrHandle(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
+memsize wrap_partSetTrHandle(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
-	udword var0 = do_get_arg(effect, stat, opcode, 0);
-	udword var1 = do_get_arg(effect, stat, opcode, 1);
-	udword var2 = do_get_arg(effect, stat, opcode, 2);
-	udword var3 = do_get_arg(effect, stat, opcode, 3);
-	udword var4 = do_get_arg(effect, stat, opcode, 4);
-	memsize (*func_ptr)(udword, udword, udword, udword, udword) = (memsize (*)(udword, udword, udword, udword, udword)) opcode->function;
+    udword var0 = do_get_arg(effect, stat, opcode, 0);
+    udword var1 = do_get_arg(effect, stat, opcode, 1);
+    udword var2 = do_get_arg(effect, stat, opcode, 2);
+    udword var3 = do_get_arg(effect, stat, opcode, 3);
+    udword var4 = do_get_arg(effect, stat, opcode, 4);
+    memsize (*func_ptr)(udword, udword, udword, udword, udword) = (memsize(*)(udword, udword, udword, udword, udword))opcode->function;
 
-	return func_ptr(var0, var1, var2, var3, var4);
+    return func_ptr(var0, var1, var2, var3, var4);
 }
-
 
 void partModifyTexture(psysPtr psys, trhandle tex, udword u0, udword v0, udword u1, udword v1);
 
-memsize wrap_partModifyTexture(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
+memsize wrap_partModifyTexture(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
-	udword var0 = do_get_arg(effect, stat, opcode, 0);
-	udword var1 = do_get_arg(effect, stat, opcode, 1);
-	udword var2 = do_get_arg(effect, stat, opcode, 2);
-	udword var3 = do_get_arg(effect, stat, opcode, 3);
-	udword var4 = do_get_arg(effect, stat, opcode, 4);
-	udword var5 = do_get_arg(effect, stat, opcode, 5);
-	memsize (*func_ptr)(udword, udword, udword, udword, udword, udword) = (memsize (*)(udword, udword, udword, udword, udword, udword)) opcode->function;
+    udword var0 = do_get_arg(effect, stat, opcode, 0);
+    udword var1 = do_get_arg(effect, stat, opcode, 1);
+    udword var2 = do_get_arg(effect, stat, opcode, 2);
+    udword var3 = do_get_arg(effect, stat, opcode, 3);
+    udword var4 = do_get_arg(effect, stat, opcode, 4);
+    udword var5 = do_get_arg(effect, stat, opcode, 5);
+    memsize (*func_ptr)(udword, udword, udword, udword, udword, udword) = (memsize(*)(udword, udword, udword, udword, udword, udword))opcode->function;
 
-	return func_ptr(var0, var1, var2, var3, var4, var5);
+    return func_ptr(var0, var1, var2, var3, var4, var5);
 }
 
 void partSetMeshdata(meshdata *m);
 
-memsize wrap_partSetMeshdata(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
+memsize wrap_partSetMeshdata(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
-	udword var0 = do_get_arg(effect, stat, opcode, 0);
-	memsize (*func_ptr)(udword) = (memsize (*)(udword)) opcode->function;
+    udword var0 = do_get_arg(effect, stat, opcode, 0);
+    memsize (*func_ptr)(udword) = (memsize(*)(udword))opcode->function;
 
-	return func_ptr(var0);
+    return func_ptr(var0);
 }
 
 void etgCreateCallbackSetup(Effect *effect, sdword codeOffset);
 
-memsize wrap_etgCreateCallbackSetup(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
+memsize wrap_etgCreateCallbackSetup(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
-	udword var0 = do_get_arg(effect, stat, opcode, 0);
-	memsize (*func_ptr)(Effect *, udword) = (memsize (*)(Effect *, udword)) opcode->function;
+    udword var0 = do_get_arg(effect, stat, opcode, 0);
+    memsize (*func_ptr)(Effect *, udword) = (memsize(*)(Effect *, udword))opcode->function;
 
-	return func_ptr(effect, var0);
+    return func_ptr(effect, var0);
 }
-
 
 memsize etgSpawnNewEffect(Effect *effect, etgeffectstatic *stat, sdword nParams, ...);
 
-udword wrap_etgSpawnNewEffect(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
+udword wrap_etgSpawnNewEffect(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
-	udword nParams     = opcode->nParameters;
-	memsize intParam[8] = {0,0,0,0,0,0,0,0};
+    udword nParams = opcode->nParameters;
+    memsize intParam[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 
-	for (udword i = 0; i < nParams; i++)
-	{
-		intParam[i] = get_arg(i);
-	}
+    for (udword i = 0; i < nParams; i++)
+    {
+        intParam[i] = get_arg(i);
+    }
 
     etgSpawnNewEffect(
         effect,
-        (etgeffectstatic *) intParam[0],
-        (sdword) intParam[1], // nParams
+        (etgeffectstatic *)intParam[0],
+        (sdword)intParam[1], // nParams
         intParam[2],
         intParam[3],
         intParam[4],
@@ -74,34 +72,31 @@ udword wrap_etgSpawnNewEffect(Effect *effect, struct etgeffectstatic *stat ,etgf
         intParam[6],
         intParam[7]);
 
-	return(etgFunctionSize(nParams));
+    return (etgFunctionSize(nParams));
 }
-
 
 void etgCreateEffects(Effect *effect, etgeffectstatic *stat, sdword number, sdword dist, sdword nParams, ...);
 
-udword wrap_etgCreateEffects(Effect *effect, struct etgeffectstatic *stat ,etgfunctioncall *opcode)
+udword wrap_etgCreateEffects(Effect *effect, struct etgeffectstatic *stat, etgfunctioncall *opcode)
 {
-	udword nParams     = opcode->nParameters;
-	memsize intParam[8] = {0,0,0,0,0,0,0,0};
+    udword nParams = opcode->nParameters;
+    memsize intParam[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 
-	for (udword i = 0; i < nParams; i++)
-	{
-		intParam[i] = get_arg(i);
-	}
+    for (udword i = 0; i < nParams; i++)
+    {
+        intParam[i] = get_arg(i);
+    }
 
     etgCreateEffects(
         effect,
-        (etgeffectstatic *) intParam[0],
-        (sdword) intParam[1],
-        (sdword) intParam[2],
-        (sdword) intParam[3], // nParams
+        (etgeffectstatic *)intParam[0],
+        (sdword)intParam[1],
+        (sdword)intParam[2],
+        (sdword)intParam[3], // nParams
         intParam[4],
         intParam[5],
         intParam[6],
         intParam[7]);
 
-	return(etgFunctionSize(nParams));
+    return (etgFunctionSize(nParams));
 }
-
-


### PR DESCRIPTION
After a month of trial, error, archeology, debugging, and head scratching,

the generic C code for ETG effects is compiling and running in 64b!

![Screenshot from 2019-03-12 14-38-14](https://user-images.githubusercontent.com/21345269/54204508-a5631380-44d4-11e9-97ff-e4d5e6e3948a.png)

The screenshot may not look very impressive, but this is it: the intended behaviour, in 64b. No more huge green explosions, and no segfaults (so far).

Closes #4 

Closes #2 