### PR TITLE
Re-enable linuxfixmes

### DIFF
--- a/Linux/stuff/configure.ac
+++ b/Linux/stuff/configure.ac
@@ -124,10 +124,9 @@ fi
 
 dnl LINUX FIX ME
 AC_ARG_ENABLE(linuxfixme,
-	AS_HELP_STRING([--enable-linuxfixme],
-		[Some code is known to be problematic on Linux.
-		Enable this to try the workarounds for this code.]),
-		[linuxfixme=yes], [linuxfixme=no])
+	AS_HELP_STRING([--disable-linuxfixme],
+		[some major buggy (on linux) code exists, disable if temporary workaround isn't wanted]),
+		[linuxfixme=no], [linuxfixme=yes])
 if test "$platform_win32" = "no" ; then
     if test "x$linuxfixme" = "xyes" ; then
     	echo "* Building linux workaround build (-D_LINUX_FIX_ME) *"

--- a/src/SDL/utility.c
+++ b/src/SDL/utility.c
@@ -4394,7 +4394,7 @@ char *utyGameSystemsShutdown(void)
     if (utyTest2(SS2_SoundEngine))
     {
         // shutdown sound engine
-#if !defined(_LINUX_FIX_ME) && !defined(_X86_64_FIX_ME)
+#ifndef _LINUX_FIX_ME
         soundEventClose();
 #endif
         utyClear2(SS2_SoundEngine);
@@ -4697,7 +4697,7 @@ char *utyGameSystemsShutdown(void)
 
     if (utyTest2(SS2_ToggleKeys))
     {
-#if !defined(_LINUX_FIX_ME) && !defined(_X86_64_FIX_ME)
+#ifndef _LINUX_FIX_ME
         utyToggleKeyStatesRestore();
 #endif
     }


### PR DESCRIPTION
I don't know why I disabled them in the first place. The instabilities must have been a side-effect of the faulty assembly etg code in x86_64.

I just played a game and the program never crashed once. (It used to crash every 30s or so)

Closes #13 